### PR TITLE
Add <bfg-radio-button-group> component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ng-bootstrap-form-generator",
   "description": "Angular 2 + Bootstrap 4 Form Generator. Library provides Angular components that help quickly generate Bootstrap Form from JavaScript object. Component supports validators, help messages, and error messages.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "angular-cli": {},
   "keywords": [
@@ -26,7 +26,7 @@
   "private":false,
   "scripts": {
     "ng": "ng",
-    "start": "npm pack  ",
+    "start": "tsc && npm pack",
     "lint": "tslint \"src/**/*.ts\"",
     "test": "ng test",
     "pree2e": "webdriver-manager update --standalone false --gecko false",
@@ -46,7 +46,7 @@
     "@angular/router": "^3.3.1",
     "core-js": "^2.4.1",
     "rxjs": "^5.0.1",
-    "zone.js": "^0.7.2",
+    "zone.js": "^0.8.11",
 
     "@angular/compiler-cli": "^2.3.1",
     "@types/jasmine": "2.5.38",

--- a/src/bfg.components.ts
+++ b/src/bfg.components.ts
@@ -28,6 +28,7 @@ export class BfgGroupCustomContentComponent { }
           <bfg-checkbox *ngSwitchCase="'checkbox'" [control]='control' [form]='form'> </bfg-checkbox>
           <!-- <bfg-radio *ngSwitchCase="'radio'" [control]='control' [form]='form'> </bfg-radio>-->
           <bfg-select *ngSwitchCase="'select'" [control]='control' [form]='form'> </bfg-select>
+          <bfg-radio-button-group *ngSwitchCase="'radio-button-group'" [control]='control' [form]='form'></bfg-radio-button-group>
           <bfg-input *ngSwitchDefault [control]='control' [form]='form'></bfg-input>
         </div>
       </template >
@@ -223,6 +224,25 @@ export class BfgSelectControlComponent {
   @Input() form: FormGroup;
 }
 
+@Component({
+  selector: 'bfg-radio-button-group',
+  template: `
+  <bfg-control [control]='c' [formGroup]='form'>
+      <label>{{c.title}}</label><br/>
+      <div class="btn-group" data-toggle="buttons">
+          <label *ngFor="let opt of c.select.options" class="btn btn-secondary" [class.active]="opt.value===c.fc.value"
+          (click)="c.fc.setValue(opt.value)">
+              <input type="radio" name="options" autocomplete="off" [attr.checked]="opt.value===c.fc.value">{{opt.text}}
+          </label>
+      </div>
+  </bfg-control>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class BfgRadioButtonGroupControlComponent {
+  @Input('control') c: BfgControl;
+  @Input() form: FormGroup;
+}
 
 @Directive({
   selector: '[bfgControl]',

--- a/src/bfg.module.ts
+++ b/src/bfg.module.ts
@@ -9,6 +9,7 @@ import {
   BfgCheckboxControlComponent,
   BfgRadioControlComponent,
   BfgSelectControlComponent,
+  BfgRadioButtonGroupControlComponent,
   BfgGroupComponent,
   BfgGroupCustomContentComponent,
   BfgControlDirective
@@ -31,6 +32,7 @@ import { KeysPipe } from './keys.pipe';
     BfgCheckboxControlComponent,
     BfgRadioControlComponent,
     BfgSelectControlComponent,
+    BfgRadioButtonGroupControlComponent,
     KeysPipe,
     BfgControlDirective
   ],

--- a/src/bfg.options.ts
+++ b/src/bfg.options.ts
@@ -8,7 +8,7 @@ import { ValidationMessage, ValidationMessageFn } from './ValidationMessage';
 export type InputType = 'text'
   | 'search' | 'email' | 'url' | 'tel' | 'password'
   | 'number' | 'date' | 'color'
-  | 'checkbox' | 'hidden' | 'select';
+  | 'checkbox' | 'hidden' | 'select' | 'radio-button-group';
 
 
 export class BfgControlOptions {


### PR DESCRIPTION
Add `radio-button-group` type with Bootstrap radio button group.

```javascript
// BfgControlOptions
{
	field: 'gender',
	type: 'radio-button-group',
	title: 'Gender',
	helpText: 'Select a gender',
	select: {
		options: [
			{ text: 'Male', value: 'm' },
			{ text: 'Female', value: 'f' }
		]
	}
}
```

![image](https://cloud.githubusercontent.com/assets/1570516/26768639/a44179c2-49ec-11e7-8ca6-81c4dcdf4fc8.png)





